### PR TITLE
Size output and optional clusters

### DIFF
--- a/src/clusters.rs
+++ b/src/clusters.rs
@@ -96,7 +96,7 @@ impl<T: std::io::Write> Clusters<T> {
     ) -> Result<(), csv::Error> {
         csv_writer.write_record(vec!["representative read id", "cluster size"])?;
         for cluster_hash in self.cluster_order.iter() {
-            // guarunteed to be present
+            // guaranteed to be present
             let cluster = self.cluster_map.get(cluster_hash).unwrap();
             csv_writer.write_record(vec![&cluster.id, &cluster.size.to_string()])?;
         }

--- a/src/clusters.rs
+++ b/src/clusters.rs
@@ -9,9 +9,14 @@ use std::io;
 use super::fastx;
 use super::paired::PairedRecord;
 
+pub struct Cluster {
+    id: String,
+    size: u64,
+}
+
 pub struct Clusters<T: io::Write> {
-    cluster_map: HashMap<u64, String>,
-    cluster_csv_writer: csv::Writer<T>,
+    cluster_map: HashMap<u64, Cluster>,
+    cluster_csv_writer: Option<csv::Writer<T>>,
     total_records: u64,
     prefix_length_opt: Option<usize>,
 }
@@ -19,15 +24,19 @@ pub struct Clusters<T: io::Write> {
 impl<T: std::io::Write> Clusters<T> {
     fn insert_record(&mut self, seq_hash: u64, id: String) -> Result<bool, csv::Error> {
         self.total_records += 1;
-        match self.cluster_map.get(&seq_hash) {
-            Some(existing_id) => self
-                .cluster_csv_writer
-                .write_record(vec![existing_id, &id])
-                .map(|_| false),
+        match self.cluster_map.get_mut(&seq_hash) {
+            Some(mut cluster) => {
+                cluster.size += 1;
+                self.cluster_csv_writer.as_mut().map(|cluster_csv_writer|
+                    cluster_csv_writer.write_record(vec![&cluster.id, &id]).map(|_| false)
+                ).unwrap_or(Ok(false))
+            },
             None => {
-                let res = self.cluster_csv_writer.write_record(vec![&id, &id]);
-                self.cluster_map.insert(seq_hash, id);
-                res.map(|_| true)
+                let res_opt = self.cluster_csv_writer.as_mut().map(|cluster_csv_writer|
+                    cluster_csv_writer.write_record(vec![&id, &id]).map(|_| true)
+                );
+                self.cluster_map.insert(seq_hash, Cluster { id, size: 1 });
+                res_opt.unwrap_or(Ok(true))
             }
         }
     }
@@ -72,33 +81,45 @@ impl<T: std::io::Write> Clusters<T> {
         self.total_records
     }
 
+    pub fn write_sizes<R: std::io::Write>(&self, csv_writer: &mut csv::Writer<R>) -> Result<(), csv::Error> {
+        csv_writer.write_record(vec!["representative read id", "cluster size"])?;
+        for cluster in self.cluster_map.values() {
+            csv_writer.write_record(vec![&cluster.id, &cluster.size.to_string()])?;
+        }
+        Ok(())
+    }
+
     pub fn from_writer(
-        cluster_output: T,
+        cluster_output_opt: Option<T>,
         prefix_length_opt: Option<usize>,
         capacity: usize,
     ) -> Result<Self, csv::Error> {
-        let mut cluster_csv_writer = csv::Writer::from_writer(cluster_output);
-        cluster_csv_writer
-            .write_record(vec!["representative read id", "read id"])
-            .map(|_| {
-                let cluster_map = HashMap::with_capacity(capacity);
-                Clusters {
-                    cluster_map: cluster_map,
-                    cluster_csv_writer: cluster_csv_writer,
-                    total_records: 0,
-                    prefix_length_opt: prefix_length_opt,
-                }
+        let cluster_csv_writer_opt = cluster_output_opt.map(csv::Writer::from_writer);
+        let cluster_map = HashMap::with_capacity(capacity);
+        let cluster_csv_writer = cluster_csv_writer_opt
+            .map(|mut cluster_csv_writer| {
+                cluster_csv_writer
+                    .write_record(vec!["representative read id", "read id"])
+                    .map(|_| Some(cluster_csv_writer))
             })
+            .unwrap_or(Ok(None))?;
+        Ok(Clusters {
+             cluster_map,
+             cluster_csv_writer,
+             total_records: 0,
+             prefix_length_opt,
+        })
     }
 }
 
 impl Clusters<File> {
     pub fn from_file<P: AsRef<std::path::Path>>(
-        cluster_output_path: P,
+        cluster_output_path_opt: Option<P>,
         prefix_length_opt: Option<usize>,
         capacity: usize,
     ) -> Result<Self, csv::Error> {
-        File::create(cluster_output_path)
+        cluster_output_path_opt.map(|cluster_output_path| File::create(cluster_output_path).map(|cluster_output| Some(cluster_output)))
+            .unwrap_or(Ok(None))
             .map_err(csv::Error::from)
             .and_then(|cluster_output| {
                 Clusters::from_writer(cluster_output, prefix_length_opt, capacity)
@@ -132,7 +153,7 @@ mod test {
         let mut cluster_output = Cursor::new(Vec::new());
         {
             let mut clusters =
-                Clusters::from_writer(&mut cluster_output, Some(10), 200).expect("asdasd");
+                Clusters::from_writer(Some(&mut cluster_output), Some(10), 200).expect("asdasd");
             let seq = random_seq(20);
             let record_1 = fasta::Record::with_attrs("id_a", None, &seq);
             clusters.insert_single(&record_1).expect("don't break");
@@ -153,7 +174,7 @@ mod test {
         let mut cluster_output = Cursor::new(Vec::new());
         {
             let mut clusters =
-                Clusters::from_writer(&mut cluster_output, Some(10), 200).expect("asdasd");
+                Clusters::from_writer(Some(&mut cluster_output), Some(10), 200).expect("asdasd");
             let seq_r1 = random_seq(20);
             let seq_r2 = random_seq(20);
             let record_1_r1 = fasta::Record::with_attrs("id_a", None, &seq_r1);
@@ -174,5 +195,28 @@ mod test {
             str::from_utf8(cluster_output.into_inner().as_slice()).unwrap(),
             "representative read id,read id\nid_a,id_a\nid_a,id_b\n"
         );
+    }
+
+    #[test]
+    fn test_write_cluster_sizes() {
+        let mut cluster_output = Cursor::new(Vec::new());
+        let mut cluster_sizes_writer = Cursor::new(Vec::new());
+        {
+            let mut cluster_sizes_output = csv::Writer::from_writer(&mut cluster_sizes_writer);
+            let mut clusters =
+                Clusters::from_writer(Some(&mut cluster_output), Some(10), 200).expect("asdasd");
+            let seq1 = random_seq(20);
+            let record_1 = fasta::Record::with_attrs("id_a", None, &seq1);
+            clusters.insert_single(&record_1).expect("don't break");
+            let record_2 = fasta::Record::with_attrs("id_b", None, &seq1);
+            clusters.insert_single(&record_2).expect("don't break");
+            let seq2 = random_seq(20);
+            let record_3 = fasta::Record::with_attrs("id_c", None, &seq2);
+            clusters.insert_single(&record_3).expect("don't break");
+            clusters.write_sizes(&mut cluster_sizes_output).expect("don't break");
+        }
+        let cluster_sizes_output_inner = cluster_sizes_writer.into_inner();
+        let cluster_sizes = str::from_utf8(cluster_sizes_output_inner.as_slice()).unwrap();
+        assert_eq!(cluster_sizes, "representative read id,cluster size\nid_a,2\nid_c,1\n");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,9 +46,9 @@ macro_rules! dedup {
                 let records_r2 = $fastx::Reader::from_file(input_r2).unwrap().records();
                 let writer_r2 = $fastx::Writer::to_file(output_r2).unwrap();
                 let records = paired::PairedRecords::new(records_r1, records_r2);
-                pair(records, writer_r1, writer_r2, $clusters)
+                pair(records, writer_r1, writer_r2, &mut $clusters)
             }
-            (None, None) => single(records_r1, writer_r1, $clusters),
+            (None, None) => single(records_r1, writer_r1, &mut $clusters),
             _ => panic!("must have the same number of inputs and outputs"),
         }
     }};
@@ -62,8 +62,8 @@ fn single<
 >(
     records: R,
     mut writer: S,
-    mut clusters: clusters::Clusters<U>,
-) -> Result<clusters::Clusters<U>, Box<dyn Error>> {
+    clusters: &mut clusters::Clusters<U>,
+) -> Result<(), Box<dyn Error>> {
     for result in records {
         let record = box_bail!(result);
         box_bail!(record
@@ -75,7 +75,7 @@ fn single<
             box_bail!(writer.write_record(&record));
         }
     }
-    Ok(clusters)
+    Ok(())
 }
 
 fn pair<
@@ -87,8 +87,8 @@ fn pair<
     records: paired::PairedRecords<T, R>,
     mut writer_r1: S,
     mut writer_r2: S,
-    mut clusters: clusters::Clusters<U>,
-) -> Result<clusters::Clusters<U>, Box<dyn Error>> {
+    clusters: &mut clusters::Clusters<U>,
+) -> Result<(), Box<dyn Error>> {
     for result in records {
         let record = box_bail!(result);
 
@@ -102,7 +102,7 @@ fn pair<
             box_bail!(writer_r2.write_record(record.r2()));
         }
     }
-    Ok(clusters)
+    Ok(())
 }
 
 fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
@@ -140,7 +140,12 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
                 .long("cluster-output")
                 .help("Output cluster file")
                 .takes_value(true)
-                .default_value("clusters.csv"),
+        )
+        .arg(
+            Arg::with_name("cluster-size-output")
+                .long("cluster-size-output")
+                .help("Output cluster size file")
+                .takes_value(true)
         )
         .arg(
             Arg::with_name("prefix-length")
@@ -154,7 +159,8 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
     // presence guarunteed by clap
     let mut inputs = matches.values_of("inputs").unwrap();
     let mut outputs = matches.values_of("deduped-outputs").unwrap();
-    let cluster_output = matches.value_of("cluster-output").unwrap();
+    let cluster_output_opt = matches.value_of("cluster-output");
+    let cluster_size_output_opt = matches.value_of("cluster-size-output");
     let prefix_length_opt = matches
         .value_of("prefix-length")
         .map(|n| n.parse::<usize>().unwrap());
@@ -163,8 +169,8 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
 
     let bytes = File::open(input_r1).unwrap().metadata().unwrap().len() as usize;
     // 400 is based on the bytes per record of an example file, should be reasonable
-    let clusters =
-        clusters::Clusters::from_file(cluster_output, prefix_length_opt, bytes / 400).unwrap();
+    let mut clusters =
+        clusters::Clusters::from_file(cluster_output_opt, prefix_length_opt, bytes / 400).unwrap();
 
     match fastx::fastx_type(input_r1).unwrap() {
         fastx::FastxType::Fasta => dedup!(
@@ -188,7 +194,13 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
         fastx::FastxType::Invalid => Err(Box::new(simple_error::simple_error!(
             "input file is not a valid FASTA or FASTQ file"
         )) as Box<dyn Error>),
+    }?;
+    
+    if let Some(cluster_sizes_output) = cluster_size_output_opt {
+        let mut cluster_sizes_writer = csv::Writer::from_path(cluster_sizes_output)?;
+        clusters.write_sizes(&mut cluster_sizes_writer)?;
     }
+    Ok(clusters)
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,13 +139,13 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
                 .short("c")
                 .long("cluster-output")
                 .help("Output cluster file")
-                .takes_value(true)
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("cluster-size-output")
                 .long("cluster-size-output")
                 .help("Output cluster size file")
-                .takes_value(true)
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("prefix-length")
@@ -195,7 +195,7 @@ fn run_dedup<T: Into<std::ffi::OsString> + Clone, R: IntoIterator<Item = T>>(
             "input file is not a valid FASTA or FASTQ file"
         )) as Box<dyn Error>),
     }?;
-    
+
     if let Some(cluster_sizes_output) = cluster_size_output_opt {
         let mut cluster_sizes_writer = csv::Writer::from_path(cluster_sizes_output)?;
         clusters.write_sizes(&mut cluster_sizes_writer)?;


### PR DESCRIPTION
Adds an optional cluster size output. If the `cluster-size-output` flag is provided `idseq-dedup` will output a csv in the form:

```
representative read id,cluster size
id_one,3
```
The representative read IDs in the counts file are guaranteed to be listed in the order they appeared in the input. This is to ensure determinism in the output, though it comes at a slight performance overhead. I would like to use a seeded custom hash but that is a future feature. This feature is being added to avoid unnecessary logic inside the `RunIDSeqDedup` step of the `short-read-mngs` workflow. Right now that step parses the resulting cluster file just so it can save a file of the counts. The parsing is actually kind of time-consuming so this should make the overall step way faster. This will also enable us to make the parsing format for the clusters file a bit simpler since we don't need to include the counts. 


In addition to this change I changed the default behavior of `cluster-output`. Now if it is not included there will be no cluster file output. I think this is more intuitive and provides the user with more options without really taking anything away.